### PR TITLE
Always call Hercule on command startup

### DIFF
--- a/src/EventCommand.php
+++ b/src/EventCommand.php
@@ -58,11 +58,10 @@ abstract class EventCommand extends Command
      */
     private function getAllEventNames(): array
     {
-        return array_map(function(EventCommand $event) {
+        return array_map(function (EventCommand $event) {
             return $event->getEventName();
-        }, \array_filter($this->getApplication()->all(), function(Command $command) {
+        }, \array_filter($this->getApplication()->all(), function (Command $command) {
             return $command instanceof EventCommand;
         }));
-
     }
 }

--- a/src/EventCommand.php
+++ b/src/EventCommand.php
@@ -38,6 +38,9 @@ abstract class EventCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): void
     {
+        // Let's send the list of caught events to Hercule
+        Hercule::setHandledEvents($this->getAllEventNames());
+
         $logLevelConfigurator = new LogLevelConfigurator($output);
         $logLevelConfigurator->configureLogLevel();
 
@@ -48,5 +51,18 @@ abstract class EventCommand extends Command
         $this->output = $output;
 
         $this->executeEvent($payload);
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getAllEventNames(): array
+    {
+        return array_map(function(EventCommand $event) {
+            return $event->getEventName();
+        }, \array_filter($this->getApplication()->all(), function(Command $command) {
+            return $command instanceof EventCommand;
+        }));
+
     }
 }


### PR DESCRIPTION
Automatically call Hercule on each run.

The AentApplication can know the list of handled events, so we can directly call Hercule on each command startup (which is cool)