### PR TITLE
Void command takes unlimited arguments

### DIFF
--- a/src/Command/VoidCommand.php
+++ b/src/Command/VoidCommand.php
@@ -3,6 +3,8 @@
 
 namespace TheAentMachine\Command;
 
+use Symfony\Component\Console\Input\InputArgument;
+
 /**
  * A command that does nothing
  */
@@ -12,6 +14,7 @@ final class VoidCommand extends AbstractEventCommand
     {
         parent::configure();
         $this->setHidden(true);
+        $this->addArgument('void_args', InputArgument::IS_ARRAY, 'stub arguments');
     }
 
     protected function getEventName(): string


### PR DESCRIPTION
Otherwise, the void command can fail if more than 2 parameters are passed to an event that does not exist